### PR TITLE
Add a script to retimestamp all commits on a branch

### DIFF
--- a/git-retimestamp
+++ b/git-retimestamp
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+
+################################################################################
+#
+#   Description:
+#   ------------
+#       Resets the timestamps of all commits in the currently checked out branch
+#       to the current time.
+#
+#       The only reason you'd want to do this is to ensure that GitHub displays
+#       the commits in pull requests in the correct order (i.e. according to the
+#       parent-child relationship of the commits and not according to the time
+#       when a commit was originally made). As such, this is only relevant to
+#       code that is hosted on GitHub. Moreover, this script would become
+#       obsolete if GitHub one day stops making nonsensical statements about
+#       git rebases altering the space-time continuum and instead just fixes its
+#       code. For more information, refer to:
+#       https://help.github.com/articles/why-are-my-commits-in-the-wrong-order/
+#
+#   Usage:
+#   ------
+#   (first place this script in one of the directories in $PATH)
+#       $> cd path/to/your/repo
+#       $> git retimestamp
+#
+################################################################################
+
+import argparse
+import git
+import sys
+
+
+################################################################################
+#
+#   Prints an error message and exits with an error status code
+#
+#   Params:
+#       msg = message to be printed before exiting
+#
+################################################################################
+
+def die(msg):
+    print msg
+    sys.exit(1)
+
+
+################################################################################
+#
+#   Displays a list of commits that will be re-timestamped, so that the user can
+#   confirm that the correct commits will be targeted
+#
+#   Params:
+#       base = the base of the branch
+#       branch_name = the name of the branch
+#
+#   Returns:
+#       the number of commits in the branch, relative to the base of the branch
+#
+################################################################################
+
+def display_commits_list(base, branch_name):
+    commits_list = git.get_commits_list(base, branch_name)
+
+    # Show the user how many (and which) commits will be modified
+    num_commits = len(commits_list)
+
+    if num_commits == 1:
+        print "The timestamps of the following commit will be reset to the current time:"
+    else:
+        print "The timestamps of the following {} commits will be reset to the current time:".format(num_commits)
+
+    commit_num = 0
+    if num_commits > 9:
+        # Show only the top and bottom 3 commits
+        for commit in commits_list[0:3]:
+            commit_num += 1
+            commit_hash, commit_title = commit.split(' ', 1)
+            sys.stdout.write('    ' + str(commit_num) + '. (\033[34m' +
+                commit_hash + '\033[0m) ' + commit_title)
+
+            if commit_num == 1:
+                sys.stdout.write("    \033[32m<-- old HEAD of '" + branch_name +
+                    "'\033[0m\n")
+            else:
+                sys.stdout.write('\n')
+
+        print "    ..."
+        print "    ... << {} more commits >> ...".format(num_commits - 6)
+        print "    ..."
+
+        commit_num = num_commits - 3
+        for commit in commits_list[-3:]:
+            commit_num += 1
+            commit_hash, commit_title = commit.split(' ', 1)
+            sys.stdout.write('    ' + str(commit_num) + '. (\033[34m' +
+                commit_hash + '\033[0m) ' + commit_title + '\n')
+    else:
+        # Show all commits
+        for commit in commits_list:
+            commit_num += 1
+            commit_hash, commit_title = commit.split(' ', 1)
+            sys.stdout.write('    ' + str(commit_num) + '. (\033[34m' +
+                commit_hash + '\033[0m) ' + commit_title)
+
+            if commit_num == 1:
+                sys.stdout.write("    \033[32m<-- old HEAD of '" + branch_name +
+                    "'\033[0m\n")
+            else:
+                sys.stdout.write('\n')
+
+    return num_commits
+
+# Set up command line arguments
+parser = argparse.ArgumentParser(usage='%(prog)s [ARGUMENTS]',
+    description='Set timestamps of all commits in a branch to the current time')
+parser.add_argument('-b', '--base', default='upstream/master',
+    help='branch (or git ref) to use as the base of the branch '
+        "(defaults to 'upstream/master')")
+args = vars(parser.parse_args())
+
+if not git.in_repo():
+    die("Not a git repository. Aborting")
+
+if not git.is_valid_commit(args['base']):
+    die("Invalid base '{}'. Aborting.".format(args['base']))
+
+branch_name = git.get_current_branch()
+if not branch_name:
+    die("No branch is currently checked out. Aborting.")
+
+num_commits = display_commits_list(args['base'], branch_name)
+
+# Ask for confirmation
+proceed = raw_input("Proceed (y/n)? ")
+if proceed != 'y' and proceed != 'Y':
+    die("Aborting.")
+
+if git.is_gpg_signing_enabled():
+    author_email = git.get_user_email()
+    if not author_email:
+        die("Failed to get the author email address. Aborting.")
+
+    gpg_sign_argument = '--gpg-sign=' + author_email
+else:
+    gpg_sign_argument = ''
+
+commits_range_argument = 'HEAD~' + str(num_commits)
+
+# Perform the actual resetting of the timestamps
+try:
+    if gpg_sign_argument:
+        git.run_command('rebase', '--ignore-date', gpg_sign_argument,
+            commits_range_argument)
+    else:
+        git.run_command('rebase', '--ignore-date', commits_range_argument)
+except git.GitException as e:
+    print "Git command '{}' failed with the following error:".format(e.args[0])
+    die(e.args[1].rstrip('\n'))
+
+print "Re-timestamp complete."
+
+# vim: set tw=80 :

--- a/git.py
+++ b/git.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python
+
+################################################################################
+#
+#   Description:
+#   ------------
+#       Generic git helper functions.
+#
+################################################################################
+
+import subprocess
+import sys
+
+
+################################################################################
+#
+#   A custom git exception class
+#
+################################################################################
+
+class GitException(Exception):
+    pass
+
+
+################################################################################
+#
+#   Runs a git command
+#
+#   Returns:
+#       the stdout output of the git command if the command succeeded
+#
+#   Throws:
+#       GitException if the git command failed. The exception will have two
+#       arguments - the first is the command that failed and the second is the
+#       stderr output
+#
+################################################################################
+
+def run_command(*args, **kwargs):
+    args = list(args)
+    args.insert(0, 'git')
+    kwargs['stdout'] = subprocess.PIPE
+    kwargs['stderr'] = subprocess.PIPE
+    proc = subprocess.Popen(args, **kwargs)
+    (stdout, stderr) = proc.communicate()
+    if proc.returncode != 0:
+        raise GitException(" ".join(args), stderr)
+    return stdout.rstrip('\n')
+
+
+################################################################################
+#
+#   Checks whether we are in a git repository
+#
+#   Returns:
+#       The top-level directory of the git repository if we are in one, an empty
+#       string otherwise
+#
+################################################################################
+
+def in_repo():
+    try:
+        git_top = run_command('rev-parse', '--show-toplevel')
+    except GitException as e:
+        return ""
+    return git_top
+
+
+################################################################################
+#
+#   Gets the current branch name
+#
+#   Returns:
+#       The name of the currently checked out branch if there is one, an empty
+#       string otherwise
+#
+################################################################################
+
+def get_current_branch():
+    try:
+        branch_name = run_command('symbolic-ref', '--short', 'HEAD')
+    except GitException as e:
+        return ""
+    return branch_name
+
+
+################################################################################
+#
+#   Checks whether something is a valid git commit (or an annotated tag that
+#   points at a commit)
+#
+#   Params:
+#       ref = the reference to check
+#
+#   Returns:
+#       True if the given string is a valid git commit, false otherwise
+#
+################################################################################
+
+def is_valid_commit(ref):
+    ref = ref + '^{commit}'
+    try:
+        run_command('rev-parse', '--quiet', '--short', '--verify', ref)
+    except GitException as e:
+        return False
+    return True
+
+
+################################################################################
+#
+#   Checks whether something is a valid git object of any type
+#
+#   Params:
+#       ref = the reference to check
+#
+#   Returns:
+#       True if the given string is a valid git object, false otherwise
+#
+################################################################################
+
+def is_valid_object(ref):
+    ref = ref + '^{object}'
+    try:
+        run_command('rev-parse', '--quiet', '--short', '--verify', ref)
+    except GitException as e:
+        return False
+    return True
+
+
+################################################################################
+#
+#   Gets a list of the basic details of all commits in the given range. Note
+#   that the start of the range is *not* included in the returned list.
+#
+#   Each element of the list contains the information of a single commit
+#   starting from the end of the range and going towards the start. Each element
+#   contains the short hash of the commit followed by a space followed by the
+#   title of the commit.
+#
+#   Params:
+#       start = start of the range (not included in the returned list)
+#       end = end of the range
+#
+#   Returns:
+#       A list containing the basic details of all commits in the range. An
+#       empty list if there are no commits in the range or if an error occurred.
+#
+################################################################################
+
+def get_commits_list(start, end):
+    commits_range = start + '..' + end
+
+    try:
+        git_log_output = run_command('log', '--oneline', commits_range)
+    except GitException as e:
+        print "Git command '{}' failed with the following error:".format(e.args[0])
+        print e.args[1].rstrip('\n')
+        return []
+
+    if not git_log_output:
+        # There are no commits in the range
+        return []
+
+    return git_log_output.split('\n')
+
+
+################################################################################
+#
+#   Checks whether gpg signing of commits is enabled
+#
+#   Returns:
+#       True if gpg signing of commits is enabled, false otherwise
+#
+################################################################################
+
+def is_gpg_signing_enabled():
+    try:
+        run_command('config', 'user.signingkey')
+    except GitException as e:
+        return False
+    return True
+
+
+################################################################################
+#
+#   Gets the email address of the current user
+#
+#   Returns:
+#       The email address of the current user, an empty string if an error
+#       occurred
+#
+################################################################################
+
+def get_user_email():
+    try:
+        user_email = run_command('config', 'user.email')
+    except GitException as e:
+        return ""
+    return user_email
+
+# vim: set tw=80 :


### PR DESCRIPTION
The `git-retimestamp` script resets the timestamps of all commits in the currently checked out branch to the current time.

Doing this ensures that GitHub displays the commits in pull requests in the correct order (i.e. according to the parent-child relationship of the commits and not according to the time when a commit was originally made).